### PR TITLE
fixed breaking change with dynamics instead of world_model

### DIFF
--- a/reasoners/base.py
+++ b/reasoners/base.py
@@ -175,10 +175,10 @@ class SearchAlgorithm(ABC):
 
 class Reasoner(ABC, Generic[State, Action, Example]):
     def __init__(self,
-                 dynamics: Dynamics[State, Action],
+                 world_model: Dynamics[State, Action],
                  search_config: SearchConfig[State, Action, Example],
                  search_algo: SearchAlgorithm) -> None:
-        self.dynamics = dynamics
+        self.dynamics = world_model
         self.search_config = search_config
         self.search_algo = search_algo
 


### PR DESCRIPTION
For examples that directly specify the parameter name i.e. Reasoner(world_model=...), since Reasoner has been changed to rename world_model parameter to dynamics on initialization, this would be a breaking change. Just to make sure that there are no errors when someone tries running the example, reverting naming back as a temporary workaround. 