### PR TITLE
Support large log file visualization

### DIFF
--- a/examples/browsergym/visualize.py
+++ b/examples/browsergym/visualize.py
@@ -84,10 +84,6 @@ def process_obs_for_viz(obs: dict[str, any], verbose: bool = False):
             obs["last_action"]
         )
 
-    # FIXME: the screenshot is too large to be uploaded to the visualizer server; uncomment this when the issue is fixed
-    # processed_obs["screenshot"] = compress_base64_image(processed_obs["screenshot"])
-    processed_obs["screenshot"] = str(processed_obs["screenshot"])[:50]
-
     if not verbose:
         return {
             "screenshot": processed_obs["screenshot"],
@@ -128,7 +124,9 @@ def browsergym_node_data_factory(x: MCTSNode, verbose: bool = False):
         }
 
 
-def browsergym_edge_data_factory(n: Union[MCTSNode, BeamSearchNode, DFSNode], verbose: bool = False) -> EdgeData:
+def browsergym_edge_data_factory(
+    n: Union[MCTSNode, BeamSearchNode, DFSNode], verbose: bool = False
+) -> EdgeData:
     function_calls = highlevel_action_parser.search_string(n.action)
     function_calls = sum(function_calls.as_list(), [])
 

--- a/reasoners/visualization/tree_snapshot.py
+++ b/reasoners/visualization/tree_snapshot.py
@@ -14,6 +14,7 @@ class TreeSnapshot:
         id: NodeId
         data: NodeData
         selected_edge: Optional[EdgeId] = None
+        convert_images: bool = True
 
     @dataclass
     class Edge:
@@ -21,6 +22,7 @@ class TreeSnapshot:
         source: NodeId
         target: NodeId
         data: EdgeData
+        convert_images: bool = True
 
     def __init__(self, nodes: Collection[Node], edges: Collection[Edge]) -> None:
         self.nodes: dict[NodeId, TreeSnapshot.Node] = {node.id: node for node in nodes}
@@ -51,10 +53,18 @@ class TreeSnapshot:
         return self.edges[edge_id]
 
     def out_edges(self, node_id: NodeId) -> Collection[Edge]:
-        return [self.edge(edge_id) for edge_id in self.edges if self.edge(edge_id).source == node_id]
+        return [
+            self.edge(edge_id)
+            for edge_id in self.edges
+            if self.edge(edge_id).source == node_id
+        ]
 
     def in_edges(self, node_id: NodeId) -> Collection[Edge]:
-        return [self.edge(edge_id) for edge_id in self.edges if self.edge(edge_id).target == node_id]
+        return [
+            self.edge(edge_id)
+            for edge_id in self.edges
+            if self.edge(edge_id).target == node_id
+        ]
 
     def parent(self, node_id: NodeId) -> NodeId:
         return self._parent[node_id]


### PR DESCRIPTION
In order to support large file visualization, we need to bypass the Lambda input limit size (6MB) which was constraining us. To do this, the visualizer client is changed to use the new API routes.

1. client posts to /get-upload-link: gets a pre-signed POST URL to upload the file to S3
2. client uses URL to upload file to S3 so Lambda can access it directly
3. client posts to /upload-complete: runs Lambda and returns visualizer URL